### PR TITLE
Remove Materialize Design Lite usage in the template

### DIFF
--- a/client/components/Button/Button.js
+++ b/client/components/Button/Button.js
@@ -20,8 +20,7 @@ class Button extends React.Component {
     const { className, ...other } = this.props;
     return (
       <button
-        ref={node => { this.root = node; }}
-        className={cx('mdl-button mdl-js-button', className)}
+        ref={(node) => { this.root = node; }}
         {...other}
       />
     );

--- a/client/components/Layout/Header.css
+++ b/client/components/Layout/Header.css
@@ -1,3 +1,4 @@
-.headerRow {
+/* TODO: may not need  */
+/* .headerRow {
   padding-left: 40px;
-}
+} */

--- a/client/components/Layout/Header.js
+++ b/client/components/Layout/Header.js
@@ -2,10 +2,8 @@ import React from 'react';
 import Link from '../Link';
 import Navigation from './Navigation';
 import Logo from './Logo';
-import s from './Header.css';
 
 class Header extends React.Component {
-
   componentDidMount() {
     window.componentHandler.upgradeElement(this.root);
   }
@@ -16,17 +14,11 @@ class Header extends React.Component {
 
   render() {
     return (
-      <header
-        ref={node => { this.root = node; }}
-        className="mdl-layout__header mdl-layout__header--transparent"
-      >
-        <div className={`mdl-layout__header-row ${s.headerRow}`}>
-          <Link className="mdl-layout-title" to="/">
-            <Logo />
-          </Link>
-          <div className="mdl-layout-spacer" />
-          <Navigation />
-        </div>
+      <header ref={(node) => { this.root = node; }}>
+        <Link to="/">
+          <Logo />
+        </Link>
+        <Navigation />
       </header>
     );
   }

--- a/client/components/Layout/Layout.css
+++ b/client/components/Layout/Layout.css
@@ -1,3 +1,4 @@
+/* TODO: may not need */
 body {
   background-color: #000000;
 }

--- a/client/components/Layout/Layout.js
+++ b/client/components/Layout/Layout.js
@@ -14,19 +14,17 @@ class Layout extends React.Component {
 
   render() {
     return (
-      <div className="mdl-layout mdl-js-layout" ref={node => { this.root = node; }}>
-        <div className="mdl-layout__inner-container">
-          <div className={s.ribbon}>
-            <Header />
-            <div className={s.container}>
-              <h1 className={`mdl-typography--title ${s.tagline}`}>Introducing the Myao Mirror</h1>
-              <p className={`mdl-typography--body-1 ${s.summary}`}>
-                The bestest smartest mirror ever.
-              </p>
-            </div>
+      <div ref={(node) => { this.root = node; }}>
+        <div className={s.ribbon}>
+          <Header />
+          <div className={s.container}>
+            <h1 className={s.tagline}>Introducing the Myao Mirror</h1>
+            <p className={s.summary}>
+              The bestest smartest mirror ever.
+            </p>
           </div>
-          <main {...this.props} className={s.content} />
         </div>
+        <main {...this.props} className={s.content} />
       </div>
     );
   }

--- a/client/components/Layout/Navigation.js
+++ b/client/components/Layout/Navigation.js
@@ -12,10 +12,10 @@ class Navigation extends React.Component {
 
   render() {
     return (
-      <nav className="mdl-navigation" ref={(node) => { this.root = node; }}>
-        <Link className="mdl-navigation__link" to="/">Home</Link>
-        <Link className="mdl-navigation__link" to="/about">About</Link>
-        <Link className="mdl-navigation__link" to="/not-found">Not Found</Link>
+      <nav ref={(node) => { this.root = node; }}>
+        <Link to="/">Home</Link>
+        <Link to="/about">About</Link>
+        <Link to="/not-found">Not Found</Link>
       </nav>
     );
   }

--- a/client/views/about/About.js
+++ b/client/views/about/About.js
@@ -9,20 +9,14 @@ class About extends React.Component {
   render() {
     return (
       <Layout>
-        <div className="mdl-grid">
-          <div className="mdl-cell mdl-cell--6-col">
-            <h1 className="mdl-typography--title">About Mirror</h1>
-            <p className="mdl-typography--body-1">
-              Coming soon.
-            </p>
-          </div>
-          <div className="mdl-cell mdl-cell--6-col">
-            <h1 className="mdl-typography--title">Mirror Stuff</h1>
-            <p className="mdl-typography--body-1">
-              This mirror is the most awesome mirror ever.
-            </p>
-          </div>
-        </div>
+        <h1>About Mirror</h1>
+        <p>
+          Coming soon.
+        </p>
+        <h1>Mirror Stuff</h1>
+        <p>
+          This mirror is the most awesome mirror ever.
+        </p>
       </Layout>
     );
   }

--- a/client/views/home/Home.js
+++ b/client/views/home/Home.js
@@ -17,39 +17,32 @@ class Home extends React.Component {
   render() {
     return (
       <Layout>
-        <div className="mdl-grid">
-          <div className="mdl-cell mdl-cell--6-col">
-            <h1 className="mdl-typography--title">Welcome to {title}!</h1>
-            <p className="mdl-typography--body-1">
-              For more information visit <a href={link1}>{link1}</a>.
-            </p>
-          </div>
-          <div className="mdl-cell mdl-cell--6-col">
-            <h1 className="mdl-typography--title">Featured Technologies</h1>
-            <ul>
-              {this.props.articles.map((article, i) => (
-                <li key={i}>
-                  <span className="mdl-typography--menu">
-                    <a href={article.url} className="mdl-typography--font-bold">
-                      {article.title}
-                    </a> [{article.author}]
-                  </span>
-                  <ul>
-                    {article.includes.map((product, n) => (
-                      <li key={n}>
-                        <span className="mdl-typography--menu mdl-typography--font-thin">
-                          <a href={product.url}>
-                            {product.title}
-                          </a> [{product.author}]
-                        </span>
-                      </li>))}
-                  </ul>
-                </li>))
-              }
-            </ul>
-            <p />
-          </div>
-        </div>
+        <h1>Welcome to {title}!</h1>
+        <p>
+          For more information visit <a href={link1}>{link1}</a>.
+        </p>
+        <h1>Featured Technologies</h1>
+        <ul>
+          {this.props.articles.map((article, i) => (
+            <li key={i}>
+              <span>
+                <a href={article.url}>
+                  {article.title}
+                </a> [{article.author}]
+              </span>
+              <ul>
+                {article.includes.map((product, n) => (
+                  <li key={n}>
+                    <span>
+                      <a href={product.url}>
+                        {product.title}
+                      </a> [{product.author}]
+                    </span>
+                  </li>))}
+              </ul>
+            </li>))
+          }
+        </ul>
       </Layout>
     );
   }


### PR DESCRIPTION
I think I removed all of the uses of MDL in the template, except for the markdown files.
So the template right now loses some of the layout, like columns etc. But that shouldn't be a problem since we most likely wouldn't rely on that.